### PR TITLE
Roll your own Shapeless

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+/bin/

--- a/src/main/scala/shapely/HList.scala
+++ b/src/main/scala/shapely/HList.scala
@@ -12,7 +12,7 @@ final case class HCons[H, T <: HList](head: H, tail: T) extends HList {
   def ++[L <: HList](xs: L) = HCons(head, tail ++ xs)
 }
 
-case object HNil0 extends HList {
+private[shapely] case object HNil0 extends HList {
   type Append[L <: HList] = L
 
   def ++[L <: HList](xs: L) = xs

--- a/src/main/scala/shapely/ops.scala
+++ b/src/main/scala/shapely/ops.scala
@@ -7,27 +7,27 @@ trait Remover[A, L <: HList] {
 }
 
 private[shapely] trait RemoverLowPriorityImplicits {
+  type Aux[A, L <: HList, O <: HList] = Remover[A, L] { type Out = O }
 
-  implicit def base[A, L <: HList]: Remover.Aux[A, A :: L, L] = new Remover[A, A :: L] {
-    type Out = L
+  implicit def nilRemove[A]: Remover[A, HNil] = new Remover[A, HNil] {
+    type Out = HNil
 
-    def apply(xs: A :: L) = xs.tail
-  }
-}
-
-object Remover extends RemoverLowPriorityImplicits {
-  type Aux[A, L <: HList, Out0 <: HList] = Remover[A, L] { type Out = Out0 }
-
-  implicit def corecurseRemove[A, L <: HList](implicit R: Remover[A, L]): Remover.Aux[A, A :: L, R.Out] = new Remover[A, A :: L] {
-    type Out = R.Out
-
-    def apply(xs: A :: L) = R(xs.tail)
+    def apply(xs: HNil) = HNil
   }
 
   implicit def corecurseRebuild[A, B, L <: HList](implicit R: Remover[A, L]): Remover.Aux[A, B :: L, B :: R.Out] = new Remover[A, B :: L] {
     type Out = B :: R.Out
 
     def apply(xs: B :: L) = xs.head :: R(xs.tail)
+  }
+}
+
+object Remover extends RemoverLowPriorityImplicits {
+
+  implicit def corecurseRemove[A, L <: HList](implicit R: Remover[A, L]): Remover.Aux[A, A :: L, R.Out] = new Remover[A, A :: L] {
+    type Out = R.Out
+
+    def apply(xs: A :: L) = R(xs.tail)
   }
 }
 

--- a/src/main/scala/shapely/ops.scala
+++ b/src/main/scala/shapely/ops.scala
@@ -9,10 +9,10 @@ trait Remover[A, L <: HList] {
 private[shapely] trait RemoverLowPriorityImplicits {
   type Aux[A, L <: HList, O <: HList] = Remover[A, L] { type Out = O }
 
-  implicit def corecurseEnd[A]: Remover[A, HNil] = new Remover[A, HNil] {
+  implicit def corecurseEnd[A]: Remover.Aux[A, HNil, HNil] = new Remover[A, HNil] {
     type Out = HNil
 
-    def apply(xs: HNil) = HNil
+    def apply(xs: HNil) = xs
   }
 
   implicit def corecurseRebuild[A, B, L <: HList](implicit R: Remover[A, L]): Remover.Aux[A, B :: L, B :: R.Out] = new Remover[A, B :: L] {

--- a/src/main/scala/shapely/ops.scala
+++ b/src/main/scala/shapely/ops.scala
@@ -9,7 +9,7 @@ trait Remover[A, L <: HList] {
 private[shapely] trait RemoverLowPriorityImplicits {
   type Aux[A, L <: HList, O <: HList] = Remover[A, L] { type Out = O }
 
-  implicit def nilRemove[A]: Remover[A, HNil] = new Remover[A, HNil] {
+  implicit def corecurseEnd[A]: Remover[A, HNil] = new Remover[A, HNil] {
     type Out = HNil
 
     def apply(xs: HNil) = HNil

--- a/src/test/scala/shapely/HListTest.scala
+++ b/src/test/scala/shapely/HListTest.scala
@@ -34,38 +34,38 @@ object HListTest {
   {
     val xs = 1 :: false :: HNil
 
-    xs.remove[Int].head: Boolean // TODO: xs.remove[Int]: Boolean :: HNil
-    xs.remove[Boolean].head: Int // TODO: xs.remove[Boolean]: Int :: HNil
+    xs.remove[Int]: Boolean :: HNil
+    xs.remove[Boolean]: Int :: HNil
   }
 
   // remove should work for type that is not contained
   {
     val xs = 1 :: false :: HNil
 
-    xs.remove[String].head: Int // TODO: xs.remove[String]: Boolean :: Int :: HNil
+    xs.remove[String]: Int :: Boolean :: HNil
   }
 
   // remove should work for multiple instance of the same type (1)
   {
     val xs = 1 :: 1 :: false :: HNil
 
-    xs.remove[Int].head: Boolean // TODO: xs.remove[Int]: Boolean :: HNil
-    xs.remove[Boolean].head: Int // TODO: xs.remove[Boolean]: Int :: Int :: HNil
+    xs.remove[Int]: Boolean :: HNil
+    xs.remove[Boolean]: Int :: Int :: HNil
   }
 
   // remove should work for multiple instance of the same type (2)
   {
     val xs = 1 :: false :: 1 :: HNil
 
-    xs.remove[Int].head: Boolean // TODO: xs.remove[Int]: Boolean :: HNil
-    xs.remove[Boolean].head: Int // TODO: xs.remove[Boolean]: Int :: Int :: HNil
+    xs.remove[Int]: Boolean :: HNil
+    xs.remove[Boolean]: Int :: Int :: HNil
   }
 
   // remove should work for empty HList
   {
     val xs = HNil
 
-    xs.remove[Int] // TODO: xs.remove[Int]: HNil
+    xs.remove[Int]: HNil
   }
 
   // map should process each element

--- a/src/test/scala/shapely/HListTest.scala
+++ b/src/test/scala/shapely/HListTest.scala
@@ -1,6 +1,6 @@
 package shapely
 
-object HListTest extends App {
+object HListTest {
 
   // result should have proper type
   {

--- a/src/test/scala/shapely/HListTest.scala
+++ b/src/test/scala/shapely/HListTest.scala
@@ -1,32 +1,74 @@
 package shapely
 
-object HListTest {
+object HListTest extends App {
 
+  // result should have proper type
+  {
+    val xs = 1 :: false :: "hi" :: HNil
+
+    xs: Int :: Boolean :: String :: HNil
+  }
+
+  // head should return proper type
   {
     val xs = 1 :: false :: "hi" :: HNil
 
     xs.head: Int
   }
 
-  {
-    val xs: Int :: Boolean :: HNil = 1 :: false :: HNil
-
-    xs.tail.head: Boolean
-  }
-
-  {
-    val xs = (1 :: HNil) ++ (false :: HNil)
-
-    xs.tail.head: Boolean
-  }
-
+  // head should return proper type
   {
     val xs = 1 :: false :: HNil
 
-    xs.remove[Int].head: Boolean
-    xs.remove[Boolean].head: Int
+    xs.tail: Boolean :: HNil
   }
 
+  // ++ should concatenate properly
+  {
+    val xs = (1 :: HNil) ++ (false :: HNil)
+
+    xs: Int :: Boolean :: HNil
+  }
+
+  // remove should have proper type
+  {
+    val xs = 1 :: false :: HNil
+
+    xs.remove[Int].head: Boolean // TODO: xs.remove[Int]: Boolean :: HNil
+    xs.remove[Boolean].head: Int // TODO: xs.remove[Boolean]: Int :: HNil
+  }
+
+  // remove should work for type that is not contained
+  {
+    val xs = 1 :: false :: HNil
+
+    xs.remove[String].head: Int // TODO: xs.remove[String]: Boolean :: Int :: HNil
+  }
+
+  // remove should work for multiple instance of the same type (1)
+  {
+    val xs = 1 :: 1 :: false :: HNil
+
+    xs.remove[Int].head: Boolean // TODO: xs.remove[Int]: Boolean :: HNil
+    xs.remove[Boolean].head: Int // TODO: xs.remove[Boolean]: Int :: Int :: HNil
+  }
+
+  // remove should work for multiple instance of the same type (2)
+  {
+    val xs = 1 :: false :: 1 :: HNil
+
+    xs.remove[Int].head: Boolean // TODO: xs.remove[Int]: Boolean :: HNil
+    xs.remove[Boolean].head: Int // TODO: xs.remove[Boolean]: Int :: Int :: HNil
+  }
+
+  // remove should work for empty HList
+  {
+    val xs = HNil
+
+    xs.remove[Int] // TODO: xs.remove[Int]: HNil
+  }
+
+  // map should process each element
   {
     val xs = 1 :: false :: HNil
 
@@ -35,19 +77,25 @@ object HListTest {
       implicit val b = at[Boolean] { !_ }
     }
 
+    xs.map(doubleFlip): Int :: Boolean :: HNil
+  }
+
+  // map should return proper types
+  {
+    val xs = 1 :: false :: HNil
+
     object toString extends Poly {
       implicit def default[A] = at[A] { _.toString }
     }
 
-    xs map doubleFlip
-
-    xs map toString head: String
+    xs.map(toString): String :: String :: HNil
   }
 
+  // nth should return proper type
   {
     val xs = 1 :: false :: HNil
 
-    xs.nth(0)
-    xs.nth(1)
+    xs.nth(0): Int
+    xs.nth(1): Boolean
   }
 }


### PR DESCRIPTION
**--- ignore this one as I resolved the mentioned issue in the subsequent one ---**

Hi Daniel,

First of all my compliments on your talk at Scala Days. I really enjoyed it and it inspired me to indeed try to roll my own `Shapeless`. Not to replace the original one, but solely for learning purposes ;-).

The `HList` definitions went fine and for the `concat`/`append` I had to peek a bit at your solution. The `remove` was more difficult and after considerable peeking I had the same solution as you did, but I could not get it to work with my own tests.

My tests differed from yours in that I had the same type multiple times in the `HList`, which your code does not seem to be capable of dealing with. Having learned a lot in the meantime I set out to fix it and went back to an elementary list implementation (not tail recursive, mind you):

``` scala
  def remove[A](list: List[A], a: A): List[A] = list match {
    case `a` :: t => remove(t, a)
    case h :: t => h :: remove(t, a)
    case Nil => Nil
  }
```

The first case is basically the equivalent of the `corecurseRemove` and the second case is the equivalent of `corecurseRebuild`. However, the third case is not equivalent with the `base` remover. Moreover, the first case should get priority over the second.

So I've adapted the removers in the following way:
- `corecurseBuild` is moved up in the hierarchy to give it less priority
- `base` is replaced by `corecurseEnd` which solely handles the `HNil` case
- I've also added some of my tests to `HListTest`, along with some test descriptions

With these changes the `remove` seems to work as intended. The only thing that I cannot get to work is the following:

The current tests are implemented by type-checking the head of the result value. Rather than only type-checking the head, I wanted to type-check the complete value. So instead of writing:

``` scala
  {
    val xs = 1 :: false :: HNil
    xs.remove[Int].head: Boolean
  }
```

I want to write:

``` scala
  xs.remove[Int]: Boolean :: HNil
```

But then I get a type error, so something still isn't entirely right with the `corecurseEnd`, because the type-check _does_ work for `concat` and `map`. Or maybe it is a compiler flaw, because the implementation does work as intended; I don't know. Anyway, I've added my tests as a `TODO` comment. I'd be interested in your view on this.

Anyway, thanks again for the inspiration. I really learned a lot about type-level programming.

Groets, Hugo.

PS: By the way, I was able to get rid of the `HNil0` object by moving it into the package object, renaming it to `HNil` and only adding a type alias: `type HNil = HNil.type`. If I try to do the same when the `HNil` object is declared in the package (instead of in the package object), then it does not work. So the compiler apparently treats package scope differently from package object scope, which seems like a glitch to me.
